### PR TITLE
Change plan color and width

### DIFF
--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -297,7 +297,8 @@ export const MapPage = () => {
                 id: "plan",
                 type: 'Feature',
                 properties: {
-                    color: `blue`
+                    color: `orange`,
+                    width: 3,
                 },
                 geometry: {
                     coordinates: plan.Poses.map((pose) => {


### PR DESCRIPTION
![image](https://github.com/cedbossneo/openmower-gui/assets/20702322/6e6b22a4-38f5-4e04-b0ef-8bac4a2795fe)
Blue color is already used by the paths and bigger width for the plan allows to hide the underlying path is any.