### PR TITLE
Fix mower heading line

### DIFF
--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -68,7 +68,7 @@ export const MapPage = () => {
             const mower_lonlat = transpose(offsetX, offsetY, datum, pose.Pose?.Pose?.Position?.Y!!, pose.Pose?.Pose?.Position?.X!!)
             setFeatures(oldFeatures => {
                 let orientation = pose.MotionHeading!!;
-                const line = drawLine(mower_lonlat[0], mower_lonlat[1], orientation)
+                const line = drawLine(offsetX, offsetY, datum, pose.Pose?.Pose?.Position?.Y!!, pose.Pose?.Pose?.Position?.X!!, orientation);
                 return {
                     ...oldFeatures, mower: {
                         id: "mower",

--- a/web/src/utils/map.tsx
+++ b/web/src/utils/map.tsx
@@ -5,7 +5,6 @@ import {Converter} from 'usng.js'
 export var converter = new Converter();
 export const earth = 6371008.8;  //radius of the earth in kilometer
 export const pi = Math.PI;
-export const meterInDegree = (1 / ((2 * pi / 360) * earth));  //1 meter in degree
 
 export function getQuaternionFromHeading(heading: number): Quaternion {
     const q = {
@@ -19,12 +18,10 @@ export function getQuaternionFromHeading(heading: number): Quaternion {
     return q
 }
 
-export function drawLine(longitude: number, latitude: number, orientation: number): [number, number] {
-    let degrees = orientation;
-    const endLongitude = longitude + Math.cos(degrees + 0.180) * meterInDegree;
-    const endLatitude = latitude + Math.sin(degrees + 0.180) * meterInDegree;
-
-    return [endLongitude, endLatitude];
+export function drawLine(offsetX: number, offsetY: number, datum: [number, number, number], y: number, x: number, orientation: number): [number, number] {
+    const endX = x + Math.cos(orientation);
+    const endY = y + Math.sin(orientation);
+    return transpose(offsetX, offsetY, datum, endY, endX);
 }
 
 export const transpose = (offsetX: number, offsetY: number, datum: [number, number, number], y: number, x: number): [number, number] => {


### PR DESCRIPTION
The heading line was not drawn accurately on my map, would be visibly off by up to 15-20deg when mower is clearly travelling in a straight line that is not directly N/S/E/W.
Changing it to calculate the endpoint on the 2d mower map coordinates then transposing to lat/lon is working much better.