### PR TITLE
Proxy websockets

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
         proxy: {
             '/api': {
                 target: 'http://localhost:4006',
+                ws: true,
             }
         }
     }


### PR DESCRIPTION
Without this, when running `npm run dev` in `web/`, I can see the settings from "upstream", but the status etc. isn't available.