### PR TITLE
Allow secure websockets

### DIFF
--- a/web/src/hooks/useWS.ts
+++ b/web/src/hooks/useWS.ts
@@ -27,7 +27,8 @@ export const useWS = <T>(onError: (e: Error) => void, onInfo: (msg: string) => v
     });
     const start = (uri: string) => {
         setFirst(true)
-        setUri(`ws://${window.location.host}${uri}`)
+        const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+        setUri(`${protocol}://${window.location.host}${uri}`)
     };
     const stop = () => {
         console.log(`Closing stream ${ws.getWebSocket()?.url}`)


### PR DESCRIPTION
Use secure wss:// websocket connections when connected via https 

> Why?

I need to run my instance behind an https proxy to make it embeddable as an iframe inside home assistant. That would be all well and good but webbrowsers refuse to allow connections to insecure websockets from a secure origin (the proxied webpage).