### PR TITLE
Add GeoJSON import/export and box selection

### DIFF
--- a/web/src/components/DrawControl.tsx
+++ b/web/src/components/DrawControl.tsx
@@ -1,7 +1,7 @@
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
-import type {ControlPosition} from 'react-map-gl';
 import {useControl} from 'react-map-gl';
 import {useEffect} from "react";
+import DirectSelectWithBoxMode from '../modes/DirectSelectWithBoxMode';
 
 type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
     position?: ControlPosition;
@@ -12,22 +12,32 @@ type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
     onUpdate: (evt: any) => void;
     onCombine: (evt: any) => void;
     onDelete: (evt: any) => void;
+    onModeChange: (mode: string) => void;
 };
 
 export default function DrawControl(props: DrawControlProps) {
     const mp = useControl<MapboxDraw>(
-        () => new MapboxDraw(props),
-        ({map}) => {
+        () => new MapboxDraw({
+            ...props,
+            modes: {
+                ...MapboxDraw.modes,
+                direct_select: DirectSelectWithBoxMode
+            }
+        }),
+        ({ map }) => {
             map.on('draw.create', props.onCreate);
             map.on('draw.update', props.onUpdate);
             map.on('draw.combine', props.onCombine);
             map.on('draw.delete', props.onDelete);
+            map.on('draw.modechange', (e) => props.onModeChange(e.mode));
+
         },
         ({map}) => {
             map.off('draw.create', props.onCreate);
             map.off('draw.update', props.onUpdate);
             map.off('draw.combine', props.onCombine);
             map.off('draw.delete', props.onDelete);
+            map.off('draw.modechange', (e) => props.onModeChange(e.mode));
         }
         ,
         {

--- a/web/src/components/DrawControl.tsx
+++ b/web/src/components/DrawControl.tsx
@@ -1,4 +1,5 @@
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import type {ControlPosition} from 'react-map-gl';
 import {useControl} from 'react-map-gl';
 import {useEffect} from "react";
 import DirectSelectWithBoxMode from '../modes/DirectSelectWithBoxMode';

--- a/web/src/modes/DirectSelectWithBoxMode.tsx
+++ b/web/src/modes/DirectSelectWithBoxMode.tsx
@@ -86,7 +86,7 @@ DirectSelectWithBoxMode.dragFeature = function (state: any, e: any, delta: any) 
   state.dragMoveLocation = e.lngLat;
 };
 
-DirectSelectWithBoxMode.dragVertex = function (state: any, e: any, delta: any) {
+DirectSelectWithBoxMode.dragVertex = function (state: any, delta: any) {
   const selectedCoords = state.selectedCoordPaths.map((coord_path: any) => state.feature.getCoordinate(coord_path));
   const selectedCoordPoints = selectedCoords.map((coords: any) => ({
     type: Constants.geojsonTypes.FEATURE,
@@ -105,11 +105,11 @@ DirectSelectWithBoxMode.dragVertex = function (state: any, e: any, delta: any) {
 };
 
 DirectSelectWithBoxMode.clickNoTarget = function () {
-  //this.changeMode(Constants.modes.SIMPLE_SELECT, {});
+  this.changeMode(Constants.modes.SIMPLE_SELECT, {});
 };
 
 DirectSelectWithBoxMode.clickInactive = function () {
-  //this.changeMode(Constants.modes.SIMPLE_SELECT, {});
+  this.changeMode(Constants.modes.SIMPLE_SELECT, {});
 };
 
 DirectSelectWithBoxMode.clickActiveFeature = function (state: any) {
@@ -165,7 +165,6 @@ DirectSelectWithBoxMode.toDisplayFeatures = function (state: any, geojson: any, 
     geojson.properties.active = Constants.activeStates.ACTIVE;
     push(geojson);
     createSupplementaryPoints(geojson, {
-      map: this.map,
       midpoints: true,
       selectedPaths: state.selectedCoordPaths
     }).forEach(push);
@@ -243,7 +242,7 @@ DirectSelectWithBoxMode.onDrag = function (state: any, e: any) {
     lng: e.lngLat.lng - state.dragMoveLocation.lng,
     lat: e.lngLat.lat - state.dragMoveLocation.lat
   };
-  if (state.selectedCoordPaths.length > 0) this.dragVertex(state, e, delta);
+  if (state.selectedCoordPaths.length > 0) this.dragVertex(state, delta);
   else this.dragFeature(state, e, delta);
 
   state.dragMoveLocation = e.lngLat;
@@ -329,19 +328,19 @@ DirectSelectWithBoxMode.onMouseUp = DirectSelectWithBoxMode.onTouchEnd = functio
 };
 
 
-DirectSelectWithBoxMode.getSelectedVerticesInBox = function (feature, minX, minY, maxX, maxY) {
-  const selectedVertices = [];
+DirectSelectWithBoxMode.getSelectedVerticesInBox = function (feature: any, minX: number, minY: number, maxX: number, maxY: number) {
+  const selectedVertices: any[] = [];
   const coordinates = feature.getCoordinates();
 
-  const checkCoordinate = (coord, path) => {
+  const checkCoordinate = (coord: any, path: any) => {
     const point = this.map.project(coord);
     if (point.x >= minX && point.x <= maxX && point.y >= minY && point.y <= maxY) {
       selectedVertices.push(path);
     }
   };
 
-  const traverseCoordinates = (coords, basePath = '') => {
-    coords.forEach((coord, index) => {
+  const traverseCoordinates = (coords: any, basePath = '') => {
+    coords.forEach((coord: any, index: any) => {
       const currentPath = basePath ? `${basePath}.${index}` : `${index}`;
       if (Array.isArray(coord[0])) {
         traverseCoordinates(coord, currentPath);
@@ -353,33 +352,6 @@ DirectSelectWithBoxMode.getSelectedVerticesInBox = function (feature, minX, minY
 
   traverseCoordinates(coordinates);
   return selectedVertices;
-};
-
-
-DirectSelectWithBoxMode.selectVerticesInBox = function (state: any, e: any) {
-  const startPoint = state.boxStartPoint;
-  const endPoint = state.boxEndPoint;
-
-  if (!startPoint || !endPoint) return;
-
-  const minX = Math.min(startPoint[0], endPoint[0]);
-  const minY = Math.min(startPoint[1], endPoint[1]);
-  const maxX = Math.max(startPoint[0], endPoint[0]);
-  const maxY = Math.max(startPoint[1], endPoint[1]);
-
-  const box = [[minX, minY], [maxX, maxY]];
-
-  const selectedVertices = this.map.queryRenderedFeatures(box, {
-    layers: ['draw.vertex'] 
-  });
-
-  const selectedCoordPaths = selectedVertices.map((feature: any) => feature.properties.coord_path);
-
-  state.selectedCoordPaths = [...new Set([...state.selectedCoordPaths, ...selectedCoordPaths])];
-
-  const selectedCoordinates = this.pathsToCoordinates(state.featureId, state.selectedCoordPaths);
-  this.setSelectedCoordinates(selectedCoordinates);
-  this.fireActionable(state);
 };
 
 export default DirectSelectWithBoxMode;

--- a/web/src/modes/DirectSelectWithBoxMode.tsx
+++ b/web/src/modes/DirectSelectWithBoxMode.tsx
@@ -1,0 +1,385 @@
+import MapboxDraw from '@mapbox/mapbox-gl-draw';
+const {
+  createSupplementaryPoints,
+  constrainFeatureMovement,
+  doubleClickZoom,
+  moveFeatures
+} = MapboxDraw.lib;
+
+const {
+  noTarget,
+  isOfMetaType,
+  isActiveFeature,
+  isInactiveFeature,
+  isShiftDown,
+} = MapboxDraw.lib.CommonSelectors;
+const Constants = MapboxDraw.constants;
+
+const isVertex = isOfMetaType(Constants.meta.VERTEX);
+const isMidpoint = isOfMetaType(Constants.meta.MIDPOINT);
+
+const DirectSelectWithBoxMode: any = {};
+
+// INTERNAL FUNCTIONS
+
+DirectSelectWithBoxMode.fireUpdate = function () {
+  this.map.fire(Constants.events.UPDATE, {
+    action: Constants.updateActions.CHANGE_COORDINATES,
+    features: this.getSelected().map((f: any) => f.toGeoJSON())
+  });
+};
+
+DirectSelectWithBoxMode.fireActionable = function (state: any) {
+  this.setActionableState({
+    combineFeatures: false,
+    uncombineFeatures: false,
+    trash: state.selectedCoordPaths.length > 0
+  });
+};
+
+DirectSelectWithBoxMode.startDragging = function (state: any, e: any) {
+  this.map.dragPan.disable();
+  state.canDragMove = true;
+  state.dragMoveLocation = e.lngLat;
+};
+
+DirectSelectWithBoxMode.stopDragging = function (state: any) {
+  this.map.dragPan.enable();
+  state.dragMoving = false;
+  state.canDragMove = false;
+  state.dragMoveLocation = null;
+};
+
+DirectSelectWithBoxMode.onVertex = function (state: any, e: any) {
+  this.startDragging(state, e);
+  const about = e.featureTarget.properties;
+  const selectedIndex = state.selectedCoordPaths.indexOf(about.coord_path);
+  if (!isShiftDown(e) && selectedIndex === -1) {
+    state.selectedCoordPaths = [about.coord_path];
+  } else if (isShiftDown(e) && selectedIndex === -1) {
+    state.selectedCoordPaths.push(about.coord_path);
+  }
+
+  const selectedCoordinates = this.pathsToCoordinates(state.featureId, state.selectedCoordPaths);
+  this.setSelectedCoordinates(selectedCoordinates);
+};
+
+DirectSelectWithBoxMode.onMidpoint = function (state: any, e: any) {
+  this.startDragging(state, e);
+  const about = e.featureTarget.properties;
+  state.feature.addCoordinate(about.coord_path, about.lng, about.lat);
+  this.fireUpdate();
+  state.selectedCoordPaths = [about.coord_path];
+};
+
+DirectSelectWithBoxMode.pathsToCoordinates = function (featureId: any, paths: any[]) {
+  return paths.map(coord_path => ({ feature_id: featureId, coord_path }));
+};
+
+DirectSelectWithBoxMode.onFeature = function (state: any, e: any) {
+  if (state.selectedCoordPaths.length === 0) this.startDragging(state, e);
+  else this.stopDragging(state);
+};
+
+DirectSelectWithBoxMode.dragFeature = function (state: any, e: any, delta: any) {
+  moveFeatures(this.getSelected(), delta);
+  state.dragMoveLocation = e.lngLat;
+};
+
+DirectSelectWithBoxMode.dragVertex = function (state: any, e: any, delta: any) {
+  const selectedCoords = state.selectedCoordPaths.map((coord_path: any) => state.feature.getCoordinate(coord_path));
+  const selectedCoordPoints = selectedCoords.map((coords: any) => ({
+    type: Constants.geojsonTypes.FEATURE,
+    properties: {},
+    geometry: {
+      type: Constants.geojsonTypes.POINT,
+      coordinates: coords
+    }
+  }));
+
+  const constrainedDelta = constrainFeatureMovement(selectedCoordPoints, delta);
+  for (let i = 0; i < selectedCoords.length; i++) {
+    const coord = selectedCoords[i];
+    state.feature.updateCoordinate(state.selectedCoordPaths[i], coord[0] + constrainedDelta.lng, coord[1] + constrainedDelta.lat);
+  }
+};
+
+DirectSelectWithBoxMode.clickNoTarget = function () {
+  //this.changeMode(Constants.modes.SIMPLE_SELECT, {});
+};
+
+DirectSelectWithBoxMode.clickInactive = function () {
+  //this.changeMode(Constants.modes.SIMPLE_SELECT, {});
+};
+
+DirectSelectWithBoxMode.clickActiveFeature = function (state: any) {
+  state.selectedCoordPaths = [];
+  this.clearSelectedCoordinates();
+  state.feature.changed();
+};
+
+// EXTERNAL FUNCTIONS
+
+DirectSelectWithBoxMode.onSetup = function (opts: any) {
+  const featureId = opts.featureId;
+  const feature = this.getFeature(featureId);
+
+  if (!feature) {
+    throw new Error('You must provide a featureId to enter direct_select mode');
+  }
+
+  if (feature.type === Constants.geojsonTypes.POINT) {
+    throw new TypeError('direct_select mode doesn\'t handle point features');
+  }
+
+  const state = {
+    featureId,
+    feature,
+    dragMoveLocation: opts.startPos || null,
+    dragMoving: false,
+    canDragMove: false,
+    selectedCoordPaths: [], //opts.coordPath ? [opts.coordPath] : [],
+    boxSelecting: false,
+    boxStartLocation: null,
+    boxSelectElement: undefined,
+  };
+
+  this.setSelectedCoordinates(this.pathsToCoordinates(featureId, state.selectedCoordPaths));
+  this.setSelected(featureId);
+  doubleClickZoom.disable(this);
+
+  this.setActionableState({
+    trash: true
+  });
+
+  return state;
+};
+
+DirectSelectWithBoxMode.onStop = function () {
+  doubleClickZoom.enable(this);
+  this.clearSelectedCoordinates();
+};
+
+DirectSelectWithBoxMode.toDisplayFeatures = function (state: any, geojson: any, push: any) {
+  if (state.featureId === geojson.properties.id) {
+    geojson.properties.active = Constants.activeStates.ACTIVE;
+    push(geojson);
+    createSupplementaryPoints(geojson, {
+      map: this.map,
+      midpoints: true,
+      selectedPaths: state.selectedCoordPaths
+    }).forEach(push);
+  } else {
+    geojson.properties.active = Constants.activeStates.INACTIVE;
+    push(geojson);
+  }
+  this.fireActionable(state);
+};
+
+DirectSelectWithBoxMode.onTrash = function (state: any) {
+  state.selectedCoordPaths
+    .sort((a: any, b: any) => b.localeCompare(a, 'en', { numeric: true }))
+    .forEach((id: any) => state.feature.removeCoordinate(id));
+  this.fireUpdate();
+  state.selectedCoordPaths = [];
+  this.clearSelectedCoordinates();
+  this.fireActionable(state);
+  if (state.feature.isValid() === false) {
+    this.deleteFeature([state.featureId]);
+    this.changeMode(Constants.modes.SIMPLE_SELECT, {});
+  }
+};
+
+DirectSelectWithBoxMode.onMouseMove = function (state: any, e: any) {
+  const isFeature = isActiveFeature(e);
+  const onVertex = isVertex(e);
+  const isMidPoint = isMidpoint(e);
+  const noCoords = state.selectedCoordPaths.length === 0;
+  if (isFeature && noCoords) this.updateUIClasses({ mouse: Constants.cursors.MOVE });
+  else if (onVertex && !noCoords) this.updateUIClasses({ mouse: Constants.cursors.MOVE });
+  else this.updateUIClasses({ mouse: Constants.cursors.NONE });
+
+  const isDraggableItem = onVertex || isFeature || isMidPoint;
+  if (isDraggableItem && state.dragMoving) this.fireUpdate();
+
+  if (state.boxSelect) {
+    state.boxEndPoint = [e.point.x, e.point.y];
+    this.updateBoxSelect(state);
+  }
+
+  return true;
+};
+
+DirectSelectWithBoxMode.onMouseOut = function (state: any) {
+  if (state.dragMoving) this.fireUpdate();
+
+  return true;
+};
+
+DirectSelectWithBoxMode.onMouseDown = DirectSelectWithBoxMode.onTouchStart = function (state: any, e: any) {
+  if (isVertex(e)) return this.onVertex(state, e);
+  
+  if (isShiftDown(e)) {
+    this.map.dragPan.disable();
+    state.boxSelecting = true;
+    state.boxStartLocation = e.point;
+    return;
+  }
+
+  if (isActiveFeature(e)) return this.onFeature(state, e);
+  if (isMidpoint(e)) return this.onMidpoint(state, e);
+};
+
+DirectSelectWithBoxMode.onDrag = function (state: any, e: any) {
+  if (state.boxSelecting) {
+    return this.whileBoxSelect(state, e)
+  }
+
+  if (state.canDragMove !== true) return;
+  state.dragMoving = true;
+  e.originalEvent.stopPropagation();
+
+  const delta = {
+    lng: e.lngLat.lng - state.dragMoveLocation.lng,
+    lat: e.lngLat.lat - state.dragMoveLocation.lat
+  };
+  if (state.selectedCoordPaths.length > 0) this.dragVertex(state, e, delta);
+  else this.dragFeature(state, e, delta);
+
+  state.dragMoveLocation = e.lngLat;
+};
+
+DirectSelectWithBoxMode.whileBoxSelect = function (state:any, e: any) {
+  const boxEndLocation = e.point;
+  this.updateUIClasses({ mouse: Constants.cursors.ADD });
+
+  const boxElement = state.boxSelectElement;
+  if (!boxElement) {
+    state.boxSelectElement = document.createElement('div');
+    state.boxSelectElement.classList.add(Constants.classes.BOX_SELECT);
+    this.map.getContainer().appendChild(state.boxSelectElement);
+  }
+  const minX = Math.min(state.boxStartLocation.x, boxEndLocation.x);
+  const maxX = Math.max(state.boxStartLocation.x, boxEndLocation.x);
+  const minY = Math.min(state.boxStartLocation.y, boxEndLocation.y);
+  const maxY = Math.max(state.boxStartLocation.y, boxEndLocation.y);
+  const translateValue = `translate(${minX}px, ${minY}px)`;
+  state.boxSelectElement.style.transform = translateValue;
+  state.boxSelectElement.style.WebkitTransform = translateValue;
+  state.boxSelectElement.style.width = `${maxX - minX}px`;
+  state.boxSelectElement.style.height = `${maxY - minY}px`;
+};
+
+DirectSelectWithBoxMode.onClick = function (state: any, e: any) {
+  if (noTarget(e)) return this.clickNoTarget(state, e);
+  if (isActiveFeature(e)) return this.clickActiveFeature(state, e);
+  if (isInactiveFeature(e)) return this.clickInactive(state, e);
+  if (isVertex(e)) {
+    if (!isShiftDown(e)) {
+      // Clear previous selection if shift is not pressed
+      state.selectedCoordPaths = [];
+    }
+    return this.onVertex(state, e);
+  }
+  this.stopDragging(state);
+};
+
+DirectSelectWithBoxMode.onTap = function (state: any, e: any) {
+  if (noTarget(e)) return this.clickNoTarget(state, e);
+  if (isActiveFeature(e)) return this.clickActiveFeature(state, e);
+  if (isInactiveFeature(e)) return this.clickInactive(state, e);
+};
+
+DirectSelectWithBoxMode.onMouseUp = DirectSelectWithBoxMode.onTouchEnd = function (state: any, e: any) {
+  if (state.boxSelectElement) {
+    this.map.getContainer().removeChild(state.boxSelectElement);
+    state.boxSelectElement = undefined;
+  }
+  if (state.boxSelecting) {
+    // End box selection
+    state.boxSelecting = false;
+    const boxEndLocation = e.point;
+
+
+    const minX = Math.min(state.boxStartLocation.x, boxEndLocation.x);
+    const maxX = Math.max(state.boxStartLocation.x, boxEndLocation.x);
+    const minY = Math.min(state.boxStartLocation.y, boxEndLocation.y);
+    const maxY = Math.max(state.boxStartLocation.y, boxEndLocation.y);
+
+    const selectedVertices = this.getSelectedVerticesInBox(state.feature, minX, minY, maxX, maxY);
+
+
+    state.selectedCoordPaths = [...new Set([...state.selectedCoordPaths, ...selectedVertices])];
+
+    this.setSelectedCoordinates(this.pathsToCoordinates(state.featureId, state.selectedCoordPaths));
+    state.boxStartLocation = null;
+
+    this.map.dragPan.enable();
+
+    // Trigger a re-render of the feature
+    state.feature.changed();
+
+    return;
+  }
+
+  if (state.dragMoving) {
+    this.fireUpdate();
+  }
+  this.stopDragging(state);
+};
+
+
+DirectSelectWithBoxMode.getSelectedVerticesInBox = function (feature, minX, minY, maxX, maxY) {
+  const selectedVertices = [];
+  const coordinates = feature.getCoordinates();
+
+  const checkCoordinate = (coord, path) => {
+    const point = this.map.project(coord);
+    if (point.x >= minX && point.x <= maxX && point.y >= minY && point.y <= maxY) {
+      selectedVertices.push(path);
+    }
+  };
+
+  const traverseCoordinates = (coords, basePath = '') => {
+    coords.forEach((coord, index) => {
+      const currentPath = basePath ? `${basePath}.${index}` : `${index}`;
+      if (Array.isArray(coord[0])) {
+        traverseCoordinates(coord, currentPath);
+      } else {
+        checkCoordinate(coord, currentPath);
+      }
+    });
+  };
+
+  traverseCoordinates(coordinates);
+  return selectedVertices;
+};
+
+
+DirectSelectWithBoxMode.selectVerticesInBox = function (state: any, e: any) {
+  const startPoint = state.boxStartPoint;
+  const endPoint = state.boxEndPoint;
+
+  if (!startPoint || !endPoint) return;
+
+  const minX = Math.min(startPoint[0], endPoint[0]);
+  const minY = Math.min(startPoint[1], endPoint[1]);
+  const maxX = Math.max(startPoint[0], endPoint[0]);
+  const maxY = Math.max(startPoint[1], endPoint[1]);
+
+  const box = [[minX, minY], [maxX, maxY]];
+
+  const selectedVertices = this.map.queryRenderedFeatures(box, {
+    layers: ['draw.vertex'] 
+  });
+
+  const selectedCoordPaths = selectedVertices.map((feature: any) => feature.properties.coord_path);
+
+  state.selectedCoordPaths = [...new Set([...state.selectedCoordPaths, ...selectedCoordPaths])];
+
+  const selectedCoordinates = this.pathsToCoordinates(state.featureId, state.selectedCoordPaths);
+  this.setSelectedCoordinates(selectedCoordinates);
+  this.fireActionable(state);
+};
+
+export default DirectSelectWithBoxMode;

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -45,6 +45,7 @@ export const MapPage = () => {
     const {config, setConfig} = useConfig(["gui.map.offset.x", "gui.map.offset.y"])
     const envs = useEnv()
     const guiApi = useApi()
+    const [currentMode, setCurrentMode] = useState<string>('simple_select');
     const [manualMode, setManualMode] = useState<number | undefined>()
     const [tileUri, setTileUri] = useState<string | undefined>()
     const [editMap, setEditMap] = useState<boolean>(false)
@@ -549,7 +550,6 @@ export const MapPage = () => {
 
     const onCombine = useCallback((e: any) => {
         setFeatures(currFeatures => {
-            debugger
             const newFeatures = {...currFeatures};
             for (const f of e.deletedFeatures) {
                 delete newFeatures[f.id];
@@ -841,6 +841,9 @@ export const MapPage = () => {
         }, 1000)
         setOffsetY(value)
     }
+    const handleModeChange = (mode: string) => {
+        setCurrentMode(mode);
+    };
 
     if (_datumLon == 0 || _datumLat == 0) {
         return <Spinner/>
@@ -867,11 +870,14 @@ export const MapPage = () => {
                 onOk={saveMowingArea}
                 onCancel={deleteFeature}
             />
+
             <Col span={24}>
                 <Typography.Title level={2}>Map</Typography.Title>
-                <Typography.Title level={5} style={{color: "#ff0000"}}>WARNING: Beta, please backup your map before
-                    use</Typography.Title>
+                <Typography.Title level={5} style={{color: "#ff0000"}}>
+                    WARNING: Beta, please backup your map before use
+                </Typography.Title>
             </Col>
+
             <Col span={24}>
                 <MowerActions>
                     {!editMap && <Button size={"small"} type="primary" onClick={handleEditMap}
@@ -953,12 +959,16 @@ export const MapPage = () => {
                         onUpdate={onUpdate}
                         onCombine={onCombine}
                         onDelete={onDelete}
+                        onModeChange={handleModeChange}
                     />
                 </Map> : <Spinner/>}
                 {highLevelStatus.highLevelStatus.StateName === "AREA_RECORDING" &&
                     <div style={{position: "absolute", bottom: 30, right: 30, zIndex: 100}}>
                         <Joystick move={handleJoyMove} stop={handleJoyStop}/>
                     </div>}
+                <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 1000, padding: '5px 10px', background: 'rgba(255, 255, 255, 0.8)', borderRadius: '5px' }}>
+    <Typography.Text>Mode: {currentMode}</Typography.Text>
+</div>
             </Col>
         </Row>
     );

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -721,6 +721,7 @@ export const MapPage = () => {
         a.click();
         window.URL.revokeObjectURL(url);
     };
+    
     const handleRestoreMap = () => {
         /*<input id="file-input" type="file" name="name" style="display: none;" />*/
         const input = document.createElement("input");
@@ -744,6 +745,48 @@ export const MapPage = () => {
         })
         input.click();
     };
+
+    const handleDownloadGeoJSON = () => {
+        const geojson = {
+            type: "FeatureCollection",
+            features: Object.values(features)
+        };
+        const a = document.createElement("a");
+        document.body.appendChild(a);
+        a.style.display = "none";
+        const json = JSON.stringify(geojson),
+            blob = new Blob([json], { type: "application/geo+json" }),
+            url = window.URL.createObjectURL(blob);
+        a.href = url;
+        a.download = "map.geojson";
+        a.click();
+        window.URL.revokeObjectURL(url);
+    };
+
+    const handleUploadGeoJSON = () => {
+        const input = document.createElement("input");
+        input.type = "file";
+        input.style.display = "none";
+        document.body.appendChild(input);
+        input.addEventListener('change', (event) => {
+            const file = (event as unknown as ChangeEvent<HTMLInputElement>).target?.files?.[0];
+            if (!file) {
+                return;
+            }
+            const reader = new FileReader();
+            reader.onload = (event) => {
+                const geojson = JSON.parse(event.target?.result as string) as FeatureCollection;
+                const newFeatures = geojson.features.reduce((acc, feature) => {
+                    acc[feature.id as string] = feature;
+                    return acc;
+                }, {} as Record<string, Feature>);
+                setFeatures(newFeatures);
+            };
+            reader.readAsText(file);
+        });
+        input.click();
+    };
+
     const handleManualMode = async () => {
         await mowerAction(
             "high_level_control",
@@ -905,6 +948,9 @@ export const MapPage = () => {
                     >Backup Map</Button>
                     <Button size={"small"} onClick={handleRestoreMap}
                     >Restore Map</Button>
+                    <Button size={"small"} onClick={handleDownloadGeoJSON}
+                    >Download GeoJSON</Button>
+                    {editMap && <Button size={"small"} onClick={handleUploadGeoJSON}>Upload GeoJSON</Button>}
                 </MowerActions>
             </Col>
             <Col span={24}>


### PR DESCRIPTION
- The selection of points only works while you are in direct_select mode. The easiest way to tell if you are in that mode is that the midpoints of the edges of your polygon is visible.
- The editing mode is now displayed on the map, for better UI clarity.  However, since mapbox-gl-draw is buggy, it will not always report the correct mode.
- There is also an existing bug that whenever a feature is edited, this triggers an update to the props.features externally, but then this triggers an effect which deletes and recreates all the features in mapbox.  The net result is that any feature you edit is immediately deleted and replaced by a duplicate any time you let go of the mouse.
- I was unable to fix a bug where if you upload the GeoJSON and then cancel the edit, the map will still show the changes that were cancelled, until you go back in to edit mode.