### PR TITLE
Add JOSM compatibility for geojson import/export

### DIFF
--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -4,12 +4,12 @@ import {App, Button, Col, Modal, Row, Slider, Typography} from "antd";
 import {useWS} from "../hooks/useWS.ts";
 import centroid from "@turf/centroid";
 import union from "@turf/union";
-import {featureCollection, geometry, polygon} from "@turf/helpers"
+import {featureCollection, polygon} from "@turf/helpers"
 import {ChangeEvent, useCallback, useEffect, useMemo, useState} from "react";
 import {AbsolutePose, Map as MapType, MapArea, Marker, MarkerArray, Path, Twist} from "../types/ros.ts";
 import DrawControl from "../components/DrawControl.tsx";
 import Map, {Layer, Source} from 'react-map-gl';
-import type {Feature, GeoJsonProperties, Geometry} from 'geojson';
+import type {Feature, GeoJsonProperties} from 'geojson';
 import {FeatureCollection, LineString, Polygon, Position} from "geojson";
 import {MowerActions, useMowerAction} from "../components/MowerActions.tsx";
 import {MowerMapMapArea} from "../api/Api.ts";
@@ -775,7 +775,7 @@ export const MapPage = () => {
             f.id = f.properties?.id;
         }
         delete f.properties?.id;
-        
+
         // use color if no id was recovered
         if(!f.id) {
             let index = f.properties?.index

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -794,11 +794,11 @@ export const MapPage = () => {
                 case "dock":
                 case "mower":
                 case "mower-heading":
-                    f.id = type
+                    f.id = type;
                     break;
                 case "area":
                 case "navigation":
-                    f.id = type + index+"-area-0";
+                    f.id = type +"-"+ index+"-area-0";
                     break;
                 case "obstacle":
                 default:


### PR DESCRIPTION
JOSM, the Java OpenStreetMap Editor is a great performant tool to edit geojson maps.
Unfortunately it's bit of a lossy process going from om-gui -> josm -> om-gui, so here is the stuff to make it work anyway.

If anyone wants to try it, here is what you need to know:
  - Obstacles need to have the same `index` property set as their associated area
  - `index` needs to be unique (not necessarily consecutive - reordered on upload); mowing and navigation both start at 0.

To make editing easier, omit the `id` property and instead specify `type`  as `area` or `navigation` otherwise `obstacle` is assumed.