### PR TITLE
Edit names of areas

### DIFF
--- a/web/src/components/DrawControl.tsx
+++ b/web/src/components/DrawControl.tsx
@@ -13,6 +13,8 @@ type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
     onUpdate: (evt: any) => void;
     onCombine: (evt: any) => void;
     onDelete: (evt: any) => void;
+    onSelectionChange: (evt: any) => void;
+    onOpenDetails: (evt: any) => void;
 };
 
 export default function DrawControl(props: DrawControlProps) {
@@ -29,13 +31,16 @@ export default function DrawControl(props: DrawControlProps) {
             map.on('draw.update', props.onUpdate);
             map.on('draw.combine', props.onCombine);
             map.on('draw.delete', props.onDelete);
-
+            map.on('draw.selectionchange', props.onSelectionChange);
+            map.on('feature.open', props.onOpenDetails);
         },
         ({map}) => {
             map.off('draw.create', props.onCreate);
             map.off('draw.update', props.onUpdate);
             map.off('draw.combine', props.onCombine);
             map.off('draw.delete', props.onDelete);
+            map.off('draw.selectionchange', props.onSelectionChange);
+            map.off('feature.open', props.onOpenDetails);
         }
         ,
         {
@@ -72,5 +77,9 @@ DrawControl.defaultProps = {
     onDelete: () => {
     },
     onCombine: () => {
+    },
+    onSelectionChange: () => {
+    },
+    onOpenDetails: () => {
     },
 };

--- a/web/src/modes/DirectSelectWithBoxMode.tsx
+++ b/web/src/modes/DirectSelectWithBoxMode.tsx
@@ -155,6 +155,13 @@ DirectSelectWithBoxMode.onSetup = function (opts: any) {
   return state;
 };
 
+DirectSelectWithBoxMode.onKeyDown = function (state: any, e: any) {
+  if (e.key == "Enter")
+    this.map.fire('feature.open', {
+      feature: state.feature
+    });
+};
+
 DirectSelectWithBoxMode.onStop = function () {
   doubleClickZoom.enable(this);
   this.clearSelectedCoordinates();

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -185,7 +185,7 @@ export const MapPage = () => {
         },
         () => {
         });
-
+    
     useEffect(() => {
         if (envs) {
             setTileUri(envs.tileUri)
@@ -579,12 +579,12 @@ export const MapPage = () => {
         });
     }, []);
 
-    const onSelectionChange = useCallback((e: any) => {
-       
-    }, []);
+
 
 
     const onOpenDetails = useCallback((e: any) => {
+        if (!features[e.feature.id])
+            return;
         setCurrentFeature(features[e.feature.id]);
         setAreaModelOpen(true);
     }, [features]);
@@ -619,20 +619,31 @@ export const MapPage = () => {
         setEditMap(!editMap)
     }
 
-    function saveArea(e: any) {
-        if (!currentFeature)
+    function saveArea() {
+        if ((!currentFeature) || (currentFeature.id === undefined) || (currentFeature.properties === null))
             return;
+
+        const idx = currentFeature.id;
+        const name = currentFeature.properties.name;
+        const index = currentFeature.properties.index;
+
         setFeatures(currFeatures => {
             const newFeatures = {...currFeatures};
-            newFeatures[currentFeature.id].properties.title = currentFeature.properties.name;
+            if (!newFeatures[idx].properties)
+                newFeatures[idx].properties = {};
 
-            newFeatures[currentFeature.id].properties.Name = currentFeature.properties.name;
+
+            newFeatures[idx].properties.title = name;
+
+            newFeatures[idx].properties.Name = name;
             
             return {...currFeatures};
         })
+        
         setMap(map => { 
             let nmap = {...map}; 
-            map.WorkingArea[currentFeature.properties.index].Name = currentFeature.properties.name;
+            if (nmap.WorkingArea)
+                nmap.WorkingArea[index].Name = name;
        
             return nmap;
         })
@@ -663,7 +674,7 @@ export const MapPage = () => {
                 return itranspose(offsetX, offsetY, datum, point[1], point[0])
             });
 
-            areas[type][index].name = f.properties.name;
+            areas[type][index].name = f.properties?.name ?? '';
 
             if (component == "area") {
                 areas[type][index].area = {
@@ -960,7 +971,7 @@ export const MapPage = () => {
 
             <Modal
                 open={areaModelOpen}
-                title={"Edit area propperties of " + (currentFeature?.properties?.name?currentFeature?.properties?.name:currentFeature?.id)}
+                title={"Edit area properties of " + (currentFeature?.properties?.name?currentFeature?.properties?.name:currentFeature?.id)}
                 footer={[
                     <Button style={{paddingRight: 10}} key="area" onClick={saveArea}  type="primary">
                         Save
@@ -969,7 +980,7 @@ export const MapPage = () => {
                 onCancel={cancelAreaModal}>
                 <label>
                     Area Name
-                    <Input style={{paddingRight: 10}} key="areaname" name="areaname" onChange={(e) => setCurrentFeature( currentFeature => { let ncurfeature = {...currentFeature}; ncurfeature.properties.name = e.target.value; return ncurfeature;})} value={(currentFeature?.properties && currentFeature?.properties.name) ? currentFeature?.properties.name : ''} placeholder="Name of the area"/>
+                    <Input style={{paddingRight: 10}} key="areaname" name="areaname" onChange={(e) => { if (currentFeature!==undefined) { setCurrentFeature(currentFeature => { let ncurfeat = {...currentFeature} as Feature; if (!ncurfeat.properties) ncurfeat.properties ={}; ncurfeat.properties.name =  e.target.value; return ncurfeat}) } }} value={(currentFeature?.properties && currentFeature?.properties.name) ? currentFeature?.properties.name : ''} placeholder="Name of the area"/>
                 </label>
             </Modal>
 
@@ -1064,7 +1075,6 @@ export const MapPage = () => {
                         onUpdate={onUpdate}
                         onCombine={onCombine}
                         onDelete={onDelete}
-                        onSelectionChange={onSelectionChange}
                         onOpenDetails={onOpenDetails}
                     />
                 </Map> : <Spinner/>}


### PR DESCRIPTION
I made it possible to change the name of an area. In edit mode click on the area you want to give a name and click again to go in direct_select mode (midway points in lines will have a circle). 

![image](https://github.com/user-attachments/assets/bf247823-8b86-4585-9bbc-031bc33dd0e5)

Press enter to open the edit area dialog and give it a name

![image](https://github.com/user-attachments/assets/61b65919-fdb0-4a71-9041-13ccc26585fc)

Press save to change the name

![image](https://github.com/user-attachments/assets/ea7e7799-d742-410d-a44f-00e02173eef4)

This will not work yet on new areas, you need to save those first