### PR TITLE
Increase ROS timeout to 1 minute

### DIFF
--- a/pkg/providers/ros.go
+++ b/pkg/providers/ros.go
@@ -118,6 +118,8 @@ func (p *RosProvider) getNode() (*goroslib.Node, error) {
 		Name:          string(nodeName),
 		MasterAddress: string(masterUri),
 		Host:          string(nodeHost),
+		ReadTimeout:   time.Minute,
+		WriteTimeout:  time.Minute,
 	})
 	return p.node, err
 


### PR DESCRIPTION
Previously it was the default of 10 seconds, which was often timing out for me while editing maps.  It takes me ~30 seconds to add my last areas.