### PR TITLE
Fix broken CI (openocl jimtcl)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y ca-certificates curl python3 python3-pi
                                       git build-essential unzip wget autoconf automake pkg-config texinfo libtool libftdi-dev libusb-1.0-0-dev
 RUN apt-get install -y rpi.gpio-common  || true
 RUN git clone --recursive --branch rpi-common --depth=1 https://github.com/raspberrypi/openocd.git   
-RUN cd openocd && ./bootstrap with-submodules && ./configure --enable-ftdi --enable-sysfsgpio --enable-bcm2835gpio && make -j$(nproc) && make install && cd .. && rm -rf openocd
+RUN cd openocd && ./bootstrap with-submodules && ./configure --enable-ftdi --enable-sysfsgpio --enable-bcm2835gpio --enable-internal-jimtcl && make -j$(nproc) && make install && cd .. && rm -rf openocd
 RUN curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -o get-platformio.py &&    python3 get-platformio.py
 RUN python3 -m pip install --upgrade pygnssutils 
 RUN mkdir -p /usr/local/bin &&    ln -s ~/.platformio/penv/bin/platformio /usr/local/bin/platformio &&    ln -s ~/.platformio/penv/bin/pio /usr/local/bin/pio &&    ln -s ~/.platformio/penv/bin/piodebuggdb /usr/local/bin/piodebuggdb


### PR DESCRIPTION
OpenOCD now needs --enable-internal-jimtcl to build with its internally bundled jimtcl.  This should fix the CI.