### PR TITLE
Support for custom runners in workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,9 +34,9 @@ jobs:
         arch: [ linux/arm64 , linux/amd64 ]
         include:
           - arch: linux/arm64
-            builder: buildjet-4vcpu-ubuntu-2204-arm
+            builder: ${{ vars.CUSTOM_RUNNER_ARM64 || 'buildjet-4vcpu-ubuntu-2204-arm' }}
           - arch: linux/amd64
-            builder: buildjet-4vcpu-ubuntu-2204
+            builder: ${{ vars.CUSTOM_RUNNER_AMD64 || 'buildjet-4vcpu-ubuntu-2204' }}
     name: Build - ${{matrix.arch}}
     runs-on: ${{matrix.builder}}
     permissions:


### PR DESCRIPTION
Add ability to use custom runner to allow contributors without access to buildjet runners.