### PR TITLE
Fix manual mowing: blade control via behavior actions + UI state fixes

### DIFF
--- a/pkg/api/openmower.go
+++ b/pkg/api/openmower.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cedbossneo/openmower-gui/pkg/msgs/dynamic_reconfigure"
 	"github.com/cedbossneo/openmower-gui/pkg/msgs/mower_map"
 	"github.com/cedbossneo/openmower-gui/pkg/msgs/mower_msgs"
+	"github.com/cedbossneo/openmower-gui/pkg/msgs/std_msgs"
 	"github.com/cedbossneo/openmower-gui/pkg/types"
 	"github.com/docker/distribution/uuid"
 	"github.com/gin-gonic/gin"
@@ -342,6 +343,17 @@ func ServiceRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 				return
 			}
 			err = provider.CallService(c.Request.Context(), "/mower_service/start_in_area", &mower_msgs.StartInAreaSrv{}, &CallReq, &mower_msgs.StartInAreaSrvRes{})
+		case "action":
+			// Publish a behavior action string to xbot/action, e.g.
+			// "mower_logic:area_recording/start_manual_mowing". This is how the
+			// GUI reaches the active behavior's actions (the blade toggle during
+			// manual mowing), which plain service calls cannot do.
+			var CallReq std_msgs.String
+			err = c.BindJSON(&CallReq)
+			if err != nil {
+				return
+			}
+			err = provider.PublishAction(CallReq.Data)
 		default:
 			err = errors.New("unknown command")
 		}

--- a/pkg/providers/ros.go
+++ b/pkg/providers/ros.go
@@ -98,6 +98,10 @@ type RosProvider struct {
 	mowingPath                *nav_msgs.Path
 	mowingPathOrigin          orb.LineString
 	dbProvider                types2.IDBProvider
+	// actionPublisher is a long-lived publisher to xbot/action. It is created
+	// lazily and reused: a fresh publisher would drop its first message because
+	// the TCP link to the mower_logic subscriber is not established yet.
+	actionPublisher *goroslib.Publisher
 }
 
 func (p *RosProvider) getNode() (*goroslib.Node, error) {
@@ -351,6 +355,54 @@ func (p *RosProvider) Publisher(topic string, obj interface{}) (*goroslib.Publis
 		Msg:   obj,
 	})
 	return publisher, nil
+}
+
+// PublishAction publishes an action string to xbot/action (std_msgs/String),
+// which mower_logic forwards to the currently active behavior. The publisher is
+// created once and cached so that repeated toggles (e.g. blade on/off during a
+// manual mowing session) reuse the warm connection.
+func (p *RosProvider) PublishAction(action string) error {
+	// getNode() locks p.mtx itself, so call it before taking the lock to avoid
+	// a re-entrant (deadlocking) lock.
+	rosNode, err := p.getNode()
+	if err != nil {
+		return err
+	}
+
+	p.mtx.Lock()
+	pub := p.actionPublisher
+	p.mtx.Unlock()
+
+	if pub == nil {
+		newPub, err := goroslib.NewPublisher(goroslib.PublisherConf{
+			Node:  rosNode,
+			Topic: "/xbot/action",
+			Msg:   &std_msgs.String{},
+		})
+		if err != nil {
+			return err
+		}
+		p.mtx.Lock()
+		if p.actionPublisher == nil {
+			p.actionPublisher = newPub
+			pub = newPub
+		} else {
+			// Another goroutine won the race; reuse theirs.
+			pub = p.actionPublisher
+			newPub.Close()
+			newPub = nil
+		}
+		p.mtx.Unlock()
+		// Only sleep when we actually created the publisher: give it time to
+		// establish its connection to the mower_logic subscriber before the
+		// first write, otherwise the first action would be dropped.
+		if newPub != nil {
+			time.Sleep(700 * time.Millisecond)
+		}
+	}
+
+	pub.Write(&std_msgs.String{Data: action})
+	return nil
 }
 
 func (p *RosProvider) UnSubscribe(topic string, id string) {

--- a/pkg/types/mocks.go
+++ b/pkg/types/mocks.go
@@ -64,6 +64,8 @@ type MockRosProvider struct {
 	ServiceErr    error
 	PublisherErr  error
 	SubscribeErr  error
+	Actions       []string
+	ActionErr     error
 }
 
 type ServiceCall struct {
@@ -108,6 +110,16 @@ func (m *MockRosProvider) UnSubscribe(topic string, id string) {
 
 func (m *MockRosProvider) Publisher(_ string, _ interface{}) (*goroslib.Publisher, error) {
 	return nil, m.PublisherErr
+}
+
+func (m *MockRosProvider) PublishAction(action string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ActionErr != nil {
+		return m.ActionErr
+	}
+	m.Actions = append(m.Actions, action)
+	return nil
 }
 
 // Publish simulates publishing a message to all subscribers of a topic.

--- a/pkg/types/ros.go
+++ b/pkg/types/ros.go
@@ -10,4 +10,7 @@ type IRosProvider interface {
 	Subscribe(topic string, id string, cb func(msg []byte)) error
 	UnSubscribe(topic string, id string)
 	Publisher(topic string, obj interface{}) (*goroslib.Publisher, error)
+	// PublishAction publishes an action string to the xbot/action topic
+	// (std_msgs/String), e.g. "mower_logic:area_recording/start_manual_mowing".
+	PublishAction(action string) error
 }

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -32,6 +32,7 @@ import {MapToolbarMobile} from "./map/components/MapToolbarMobile.tsx";
 import {MapEditorToolbar} from "./map/components/MapEditorToolbar.tsx";
 import {JoystickOverlay} from "./map/components/JoystickOverlay.tsx";
 import {useIsMobile} from "../hooks/useIsMobile.ts";
+import {useStatus} from "../hooks/useStatus.ts";
 import {useThemeMode} from "../theme/ThemeContext.tsx";
 
 
@@ -329,7 +330,8 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     });
 
 
-    const {manualMode, bladeOn, handleManualMode, handleStopManualMode, toggleBlade, handleJoyMove, handleJoyStop} = useManualMode({mowerAction, joyStream});
+    const mowerStatus = useStatus();
+    const {manualMode, bladeOn, handleManualMode, handleStopManualMode, toggleBlade, handleJoyMove, handleJoyStop} = useManualMode({mowerAction, joyStream, mowEnabled: mowerStatus.MowEnabled});
 
     // Mower action callbacks shared between desktop and mobile toolbars
     const mowerActions = useMemo(() => ({

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -527,8 +527,8 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                     isRecording={highLevelStatus.highLevelStatus.StateName === "AREA_RECORDING"}
                     onMove={handleJoyMove}
                     onStop={handleJoyStop}
-                    onFinishRecording={mowerAction("high_level_control", {Command: 2})}
-                    onHome={mowerAction("high_level_control", {Command: 2})}
+                    onFinishRecording={manualMode != null ? handleStopManualMode : mowerAction("high_level_control", {Command: 2})}
+                    onHome={manualMode != null ? handleStopManualMode : mowerAction("high_level_control", {Command: 2})}
                     bladeOn={bladeOn}
                     onToggleBlade={toggleBlade}
                 />

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -329,7 +329,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     });
 
 
-    const {manualMode, handleManualMode, handleStopManualMode, handleJoyMove, handleJoyStop} = useManualMode({mowerAction, joyStream});
+    const {manualMode, bladeOn, handleManualMode, handleStopManualMode, toggleBlade, handleJoyMove, handleJoyStop} = useManualMode({mowerAction, joyStream});
 
     // Mower action callbacks shared between desktop and mobile toolbars
     const mowerActions = useMemo(() => ({
@@ -529,6 +529,8 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                     onStop={handleJoyStop}
                     onFinishRecording={mowerAction("high_level_control", {Command: 2})}
                     onHome={mowerAction("high_level_control", {Command: 2})}
+                    bladeOn={bladeOn}
+                    onToggleBlade={toggleBlade}
                 />
                 {isMobile && (
                     <MapToolbarMobile

--- a/web/src/pages/map/components/JoystickOverlay.tsx
+++ b/web/src/pages/map/components/JoystickOverlay.tsx
@@ -1,6 +1,6 @@
 import {Joystick} from "react-joystick-component";
 import {IJoystickUpdateEvent} from "react-joystick-component/build/lib/Joystick";
-import {CheckOutlined, HomeOutlined} from "@ant-design/icons";
+import {CheckOutlined, HomeOutlined, ThunderboltOutlined} from "@ant-design/icons";
 import AsyncButton from "../../../components/AsyncButton.tsx";
 
 interface JoystickOverlayProps {
@@ -10,34 +10,52 @@ interface JoystickOverlayProps {
     onStop: () => void;
     onFinishRecording?: () => Promise<void>;
     onHome?: () => Promise<void>;
+    bladeOn?: boolean;
+    onToggleBlade?: () => Promise<void>;
 }
 
-export const JoystickOverlay = ({visible, isRecording, onMove, onStop, onFinishRecording, onHome}: JoystickOverlayProps) => {
+export const JoystickOverlay = ({visible, isRecording, onMove, onStop, onFinishRecording, onHome, bladeOn, onToggleBlade}: JoystickOverlayProps) => {
     if (!visible) return null;
+    const showSideColumn = isRecording || onToggleBlade;
     return (
         <div style={{position: "absolute", bottom: 30, right: 30, zIndex: 100, display: 'flex', alignItems: 'flex-end', gap: 12}}>
-            {isRecording && (
+            {showSideColumn && (
                 <div style={{
                     display: 'flex',
                     flexDirection: 'column',
                     gap: 8,
                     marginBottom: 10,
                 }}>
-                    <AsyncButton
-                        type="primary"
-                        icon={<CheckOutlined />}
-                        onAsyncClick={onFinishRecording!}
-                        style={{height: 44, borderRadius: 10, fontWeight: 600}}
-                    >
-                        Finish
-                    </AsyncButton>
-                    <AsyncButton
-                        icon={<HomeOutlined />}
-                        onAsyncClick={onHome!}
-                        style={{height: 44, borderRadius: 10}}
-                    >
-                        Home
-                    </AsyncButton>
+                    {isRecording && (
+                        <>
+                            <AsyncButton
+                                type="primary"
+                                icon={<CheckOutlined />}
+                                onAsyncClick={onFinishRecording!}
+                                style={{height: 44, borderRadius: 10, fontWeight: 600}}
+                            >
+                                Finish
+                            </AsyncButton>
+                            <AsyncButton
+                                icon={<HomeOutlined />}
+                                onAsyncClick={onHome!}
+                                style={{height: 44, borderRadius: 10}}
+                            >
+                                Home
+                            </AsyncButton>
+                        </>
+                    )}
+                    {onToggleBlade && (
+                        <AsyncButton
+                            danger={bladeOn}
+                            type={bladeOn ? "primary" : "default"}
+                            icon={<ThunderboltOutlined />}
+                            onAsyncClick={onToggleBlade}
+                            style={{height: 44, borderRadius: 10, fontWeight: 600}}
+                        >
+                            {bladeOn ? "Blade ON" : "Start blade"}
+                        </AsyncButton>
+                    )}
                 </div>
             )}
             <Joystick move={onMove} stop={onStop}/>

--- a/web/src/pages/map/hooks/useManualMode.test.ts
+++ b/web/src/pages/map/hooks/useManualMode.test.ts
@@ -32,18 +32,20 @@ describe('useManualMode', () => {
         expect(result.current.manualMode).toBeUndefined();
     });
 
-    it('handleManualMode activates manual mode', async () => {
+    it('handleManualMode activates manual mode with blade off', async () => {
         const {result} = renderManualMode();
         await act(async () => {
             await result.current.handleManualMode();
         });
         expect(startStream).toHaveBeenCalledWith('/api/openmower/publish/joy');
         expect(mowerAction).toHaveBeenCalledWith('high_level_control', {Command: 3});
-        expect(mowerAction).toHaveBeenCalledWith('mow_enabled', {MowEnabled: 1, MowDirection: 0});
+        // Blade must NOT be commanded on at entry.
+        expect(mowerAction).not.toHaveBeenCalledWith('action', {Data: 'mower_logic:area_recording/start_manual_mowing'});
         expect(result.current.manualMode).toBeDefined();
+        expect(result.current.bladeOn).toBe(false);
     });
 
-    it('handleStopManualMode deactivates manual mode', async () => {
+    it('handleStopManualMode deactivates manual mode and stops the blade', async () => {
         const {result} = renderManualMode();
         await act(async () => {
             await result.current.handleManualMode();
@@ -53,9 +55,26 @@ describe('useManualMode', () => {
         await act(async () => {
             await result.current.handleStopManualMode();
         });
+        expect(mowerAction).toHaveBeenCalledWith('action', {Data: 'mower_logic:area_recording/stop_manual_mowing'});
         expect(mowerAction).toHaveBeenCalledWith('high_level_control', {Command: 2});
-        expect(mowerAction).toHaveBeenCalledWith('mow_enabled', {MowEnabled: 0, MowDirection: 0});
         expect(result.current.manualMode).toBeUndefined();
+        expect(result.current.bladeOn).toBe(false);
+    });
+
+    it('toggleBlade turns the blade on then off via xbot/action', async () => {
+        const {result} = renderManualMode();
+
+        await act(async () => {
+            await result.current.toggleBlade();
+        });
+        expect(mowerAction).toHaveBeenCalledWith('action', {Data: 'mower_logic:area_recording/start_manual_mowing'});
+        expect(result.current.bladeOn).toBe(true);
+
+        await act(async () => {
+            await result.current.toggleBlade();
+        });
+        expect(mowerAction).toHaveBeenCalledWith('action', {Data: 'mower_logic:area_recording/stop_manual_mowing'});
+        expect(result.current.bladeOn).toBe(false);
     });
 
     it('handleJoyMove sends twist message', () => {

--- a/web/src/pages/map/hooks/useManualMode.test.ts
+++ b/web/src/pages/map/hooks/useManualMode.test.ts
@@ -77,6 +77,19 @@ describe('useManualMode', () => {
         expect(result.current.bladeOn).toBe(false);
     });
 
+    it('reconciles bladeOn from the real mow_enabled (survives remount / external change)', () => {
+        const {result, rerender} = renderHook(
+            ({me}: {me?: boolean}) =>
+                useManualMode({mowerAction, joyStream: {sendJsonMessage, start: startStream}, mowEnabled: me}),
+            {initialProps: {me: undefined as boolean | undefined}}
+        );
+        expect(result.current.bladeOn).toBe(false);
+        rerender({me: true});
+        expect(result.current.bladeOn).toBe(true);
+        rerender({me: false});
+        expect(result.current.bladeOn).toBe(false);
+    });
+
     it('handleJoyMove sends twist message', () => {
         const {result} = renderManualMode();
         act(() => {

--- a/web/src/pages/map/hooks/useManualMode.ts
+++ b/web/src/pages/map/hooks/useManualMode.ts
@@ -4,6 +4,14 @@ import type {IJoystickUpdateEvent} from "react-joystick-component/build/lib/Joys
 
 const JOY_SEND_INTERVAL_MS = 100;
 
+// Behavior actions handled by AreaRecordingBehavior in mower_logic, published to
+// the xbot/action topic. Toggling the blade during manual mowing must go through
+// these: the mower_logic safety loop continuously forces the blade to match the
+// behavior's manual_mowing flag, so a direct mow_enabled service call is undone
+// within ~0.5s. These actions flip that flag, which the safety loop honors.
+const START_MANUAL_MOWING = "mower_logic:area_recording/start_manual_mowing";
+const STOP_MANUAL_MOWING = "mower_logic:area_recording/stop_manual_mowing";
+
 interface UseManualModeOptions {
     mowerAction: (action: string, params: Record<string, unknown>) => () => Promise<void>;
     joyStream: { sendJsonMessage: (msg: unknown) => void; start: (uri: string) => void };
@@ -11,6 +19,7 @@ interface UseManualModeOptions {
 
 export function useManualMode({mowerAction, joyStream}: UseManualModeOptions) {
     const [manualMode, setManualMode] = useState<number | undefined>();
+    const [bladeOn, setBladeOn] = useState(false);
     const lastTwistRef = useRef<Twist | null>(null);
     const joyIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
 
@@ -33,23 +42,27 @@ export function useManualMode({mowerAction, joyStream}: UseManualModeOptions) {
         // Don't wait for the AREA_RECORDING state to propagate back via highLevelStatus.
         joyStream.start("/api/openmower/publish/joy");
         await mowerAction("high_level_control", {Command: 3})();
-        // Enable mowing blade immediately, then keep it alive every 10s
-        await mowerAction("mow_enabled", {MowEnabled: 1, MowDirection: 0})();
-        setManualMode(setInterval(() => {
-            (async () => {
-                await mowerAction("mow_enabled", {MowEnabled: 1, MowDirection: 0})();
-            })();
-        }, 10000));
+        // Blade stays off until the user explicitly toggles it on (safer entry).
+        setBladeOn(false);
+        setManualMode(1);
     };
 
     const handleStopManualMode = async () => {
-        await mowerAction("high_level_control", {Command: 2})();
-        clearInterval(manualMode);
+        // Command the blade off via the behavior while AREA_RECORDING is still active,
+        // then transition home.
+        await mowerAction("action", {Data: STOP_MANUAL_MOWING})();
+        setBladeOn(false);
         setManualMode(undefined);
         stopJoyInterval();
         lastTwistRef.current = null;
-        await mowerAction("mow_enabled", {MowEnabled: 0, MowDirection: 0})();
+        await mowerAction("high_level_control", {Command: 2})();
     };
+
+    const toggleBlade = useCallback(async () => {
+        const next = !bladeOn;
+        await mowerAction("action", {Data: next ? START_MANUAL_MOWING : STOP_MANUAL_MOWING})();
+        setBladeOn(next);
+    }, [bladeOn, mowerAction]);
 
     const handleJoyMove = useCallback((event: IJoystickUpdateEvent) => {
         const msg: Twist = {
@@ -74,5 +87,5 @@ export function useManualMode({mowerAction, joyStream}: UseManualModeOptions) {
         joyStream.sendJsonMessage(msg);
     }, [joyStream, stopJoyInterval]);
 
-    return {manualMode, handleManualMode, handleStopManualMode, handleJoyMove, handleJoyStop};
+    return {manualMode, bladeOn, handleManualMode, handleStopManualMode, toggleBlade, handleJoyMove, handleJoyStop};
 }

--- a/web/src/pages/map/hooks/useManualMode.ts
+++ b/web/src/pages/map/hooks/useManualMode.ts
@@ -1,4 +1,4 @@
-import {useCallback, useRef, useState} from "react";
+import {useCallback, useEffect, useRef, useState} from "react";
 import type {Twist} from "../../../types/ros.ts";
 import type {IJoystickUpdateEvent} from "react-joystick-component/build/lib/Joystick";
 
@@ -15,13 +15,24 @@ const STOP_MANUAL_MOWING = "mower_logic:area_recording/stop_manual_mowing";
 interface UseManualModeOptions {
     mowerAction: (action: string, params: Record<string, unknown>) => () => Promise<void>;
     joyStream: { sendJsonMessage: (msg: unknown) => void; start: (uri: string) => void };
+    // Live blade state from /ll/mower_status.mow_enabled (the source of truth).
+    mowEnabled?: boolean;
 }
 
-export function useManualMode({mowerAction, joyStream}: UseManualModeOptions) {
+export function useManualMode({mowerAction, joyStream, mowEnabled}: UseManualModeOptions) {
     const [manualMode, setManualMode] = useState<number | undefined>();
     const [bladeOn, setBladeOn] = useState(false);
     const lastTwistRef = useRef<Twist | null>(null);
     const joyIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
+
+    // Reconcile the displayed blade state with the real mow_enabled so it survives
+    // navigating away and back (MapPage remount) and any external blade change. Fires
+    // only when the real value changes, so optimistic toggles don't flicker.
+    useEffect(() => {
+        if (mowEnabled !== undefined) {
+            setBladeOn(mowEnabled);
+        }
+    }, [mowEnabled]);
 
     const startJoyInterval = useCallback(() => {
         clearInterval(joyIntervalRef.current);


### PR DESCRIPTION
## What & why

Manual mowing currently enables the blade with a direct `mow_enabled` service call, but `mower_logic`'s safety loop continuously forces the blade to match the active behavior's `mower_enabled()` (the `manual_mowing` flag) — so the blade is reverted within ~0.5 s and never actually runs during manual mowing.

This switches the blade control to the behavior's own actions and fixes a couple of related UI state bugs.

## Changes

1. **Blade ON/OFF via behavior actions** — drive the blade through `mower_logic:area_recording/start_manual_mowing` / `stop_manual_mowing` (the actions added upstream in openmower/open_mower_ros#162) instead of the overridden `mow_enabled` service. Adds a small backend `action` command on `/openmower/call` that publishes a `std_msgs/String` to `xbot/action` via a cached `PublishAction` publisher (a fresh one-shot publisher drops its first message before the subscriber link is up). The joystick overlay gets a Blade ON/Start blade toggle.

2. **Clear the overlay/blade button on Finish/Home** — those buttons sent `high_level_control` Command 2 but never reset the manual-mode UI state, so the joystick + blade button lingered after exiting. They now route through the manual-mode teardown when active.

3. **Blade button reflects real `mow_enabled`** — the button state was local React state, lost on page navigation (component remount), so returning to the Map showed "Start blade" even with the blade running. It now reconciles from `/ll/mower_status.mow_enabled` (via `useStatus`), surviving remount and external blade changes without flickering optimistic toggles.

## Notes
- Targets the `v2` branch.
- Frontend: `npm run build` + `vitest` pass (incl. added `useManualMode` tests).
- Field-tested on a Mowgli (YardForce) running this branch.